### PR TITLE
Simply support initZygote

### DIFF
--- a/demo-module/src/main/java/com/highcapable/yukihookapi/demo_module/hook/HookEntry.kt
+++ b/demo-module/src/main/java/com/highcapable/yukihookapi/demo_module/hook/HookEntry.kt
@@ -28,6 +28,7 @@
 package com.highcapable.yukihookapi.demo_module.hook
 
 import android.app.AlertDialog
+import android.content.res.XModuleResources
 import com.highcapable.yukihookapi.YukiHookAPI
 import com.highcapable.yukihookapi.annotation.xposed.InjectYukiHookWithXposed
 import com.highcapable.yukihookapi.demo_module.data.DataConst
@@ -36,9 +37,16 @@ import com.highcapable.yukihookapi.hook.type.java.StringArrayClass
 import com.highcapable.yukihookapi.hook.type.java.StringType
 import com.highcapable.yukihookapi.hook.type.java.UnitType
 import com.highcapable.yukihookapi.hook.xposed.proxy.YukiHookXposedInitProxy
+import de.robv.android.xposed.IXposedHookZygoteInit
 
 @InjectYukiHookWithXposed
 class HookEntry : YukiHookXposedInitProxy {
+
+    override fun onStartup(param: IXposedHookZygoteInit.StartupParam) {
+        // 获取模块 APK 路径，使用 XModuleResources 创建一个 Resources。
+        // 在被 Hook 的应用中使用该 Resources 可以访问本应用内资源（drawable / string / layout 等）。
+        XModuleResources.createInstance(param.modulePath, null)
+    }
 
     override fun onInit() {
         // 配置 YuKiHookAPI

--- a/yukihookapi/src/api/kotlin/com/highcapable/yukihookapi/hook/xposed/proxy/YukiHookXposedInitProxy.kt
+++ b/yukihookapi/src/api/kotlin/com/highcapable/yukihookapi/hook/xposed/proxy/YukiHookXposedInitProxy.kt
@@ -33,6 +33,7 @@ import com.highcapable.yukihookapi.YukiHookAPI
 import com.highcapable.yukihookapi.annotation.xposed.InjectYukiHookWithXposed
 import com.highcapable.yukihookapi.hook.factory.configs
 import com.highcapable.yukihookapi.hook.factory.encase
+import de.robv.android.xposed.IXposedHookZygoteInit
 
 /**
  * [YukiHookAPI] 的 Xposed 装载 API 调用接口
@@ -50,6 +51,15 @@ import com.highcapable.yukihookapi.hook.factory.encase
  * 详情请参考 [YukiHookXposedInitProxy 接口](https://fankes.github.io/YukiHookAPI/#/config/xposed-using?id=yukihookxposedinitproxy-%e6%8e%a5%e5%8f%a3)
  */
 interface YukiHookXposedInitProxy {
+
+    /**
+     * 用于接收 [IXposedHookZygoteInit.initZygote] 事件
+     *
+     * - ❗此方法主要用于获取模块启动信息 - 不能进行 Hook 操作
+     *
+     * 此方法可选 - 如果没有需求可以不覆写
+     */
+    fun onStartup(param: IXposedHookZygoteInit.StartupParam) {}
 
     /**
      * 配置 [YukiHookAPI.Configs] 的初始化方法


### PR DESCRIPTION
The data structure of `IXposedHookZygoteInit.StartupParam` is very simple, therefor data wrapper is not created.

Been handled together, relax superclass restriction of proxy class (hook entry) to meet the complex customization needs of users.