### PR TITLE
Added getField & setField function

### DIFF
--- a/yukihookapi/src/api/kotlin/com/highcapable/yukihookapi/hook/param/HookParam.kt
+++ b/yukihookapi/src/api/kotlin/com/highcapable/yukihookapi/hook/param/HookParam.kt
@@ -30,6 +30,8 @@
 package com.highcapable.yukihookapi.hook.param
 
 import com.highcapable.yukihookapi.hook.core.YukiMemberHookCreater
+import com.highcapable.yukihookapi.hook.core.finder.FieldFinder.Result.Instance
+import com.highcapable.yukihookapi.hook.factory.field
 import com.highcapable.yukihookapi.hook.param.wrapper.HookParamWrapper
 import java.lang.reflect.Constructor
 import java.lang.reflect.Member
@@ -122,6 +124,25 @@ class HookParam(private val createrInstance: YukiMemberHookCreater, private var 
      * @return [ArgsModifyer]
      */
     fun args(index: Int) = ArgsModifyer(index)
+
+    /**
+     * 根据名称获取实例 的 Filed 实例处理类
+     *
+     * 需要获取 Field 的实例
+     * @param fieldName Field 名称
+     * @return [Instance]
+     */
+    fun Any.getField(fieldName : String) = this.javaClass.field { name = fieldName }.get(this)
+
+    /**
+     * 根据名称设置实例 的 Filed 实例内容
+     *
+     * 需要设置 Field 的实例
+     * @param fieldName Field 名称
+     * @param value 设置的实例内容
+     */
+    fun Any.setField(fieldName : String, value : Any?) =
+        this.javaClass.field { name = fieldName }.get(this).set(value)
 
     /**
      * 执行原始 [Member]


### PR DESCRIPTION
假如需要修改自定义类型实例(`innerClassInstance`)中的变量(`testString`)
``` kotlin
class HookedClass {
    inner class TestClass(){
        val testString = "String Content"
    }
    private val innerClassInstance = TestClass()
}
```
根据我已了解到的YukiHookAPI用法，我会这样写：
``` kotlin
val innerClassInstance = field { name = "innerClassInstance" }.get(instance).any()
innerClassInstance.javaclass.field { name = "testString" }.get(innerClassInstance).set("another String")
```
如果需要设置`innerClassInstance`中的很多变量就会感觉很麻烦,要写多个`innerClassInstance.javaclass`，加上这个commit后就可以写成：
```kotlin
val mField =  instance.getField("innerClassInstance").any()
mField.setField("testString", "another String")
```
这样如果需要设置`innerClassInstance`中的多个变量，就可以多写几个`mField.setField()`。而且直接对实例操作也会看起来更直观。
按照这个commit的写法，只能对 field 名称这个单一条件进行搜索，不过这个可以后续优化
我是YukiHookAPI的新手，如果已有类似简便的写法，也请麻烦告诉我一下 :-)